### PR TITLE
Samba v4.21.4-r4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,5 +25,5 @@ build-local:
 logs:
 	docker compose logs -f
 
-samba-repository-version:
-	docker run --rm alpine sh -c "apk --no-cache --no-progress update >/dev/null && apk upgrade >/dev/null && apk search -v -e samba"
+samba-repository-version: # https://pkgs.alpinelinux.org/packages?name=samba&branch=v3.22&repo=main&arch=
+	docker run --rm alpine:3 sh -c "apk --no-cache --no-progress update >/dev/null && apk upgrade >/dev/null && apk search -v -e samba | tr ' ' '\n' | grep 'samba-' | cut -d'-' -f2-"

--- a/samba/Dockerfile
+++ b/samba/Dockerfile
@@ -1,6 +1,7 @@
+ARG SAMBA_VERSION=4.21.4-r4
 ARG BUILD_DIR=/build
 ARG BUILD_TAG
-FROM alpine AS base
+FROM alpine:3 AS base
 
 
 FROM base AS build
@@ -19,8 +20,9 @@ ENV SAMBA_HOME=/opt/samba \
     SAMBA_CONF_FILE=/etc/samba/smb.conf
 
 # Install samba
+ARG SAMBA_VERSION
 RUN apk --no-cache --no-progress upgrade && \
-    apk --no-cache --no-progress add bash samba shadow tzdata && \
+    apk --no-cache --no-progress add bash "samba=$SAMBA_VERSION" shadow tzdata && \
     addgroup -S smb && \
     adduser -S -D -H -h /tmp -s /sbin/nologin -G smb -g 'Samba User' smbuser &&\
     file="$SAMBA_CONF_FILE" && \
@@ -84,6 +86,7 @@ VOLUME ["/etc", "/var/cache/samba", "/var/lib/samba", "/var/log/samba",\
             "/run/samba"]
 
 ARG BUILD_TAG
-ENV BUILD_TAG="$BUILD_TAG"
+ENV SAMBA_VERSION="$SAMBA_VERSION" \
+    BUILD_TAG="$BUILD_TAG"
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/samba/rootfs/entrypoint.sh
+++ b/samba/rootfs/entrypoint.sh
@@ -2,7 +2,7 @@
 set -eo pipefail
 eval "$(samba-env)"
 
-info "Running Samba with build version: ${BUILD_TAG}"
+info "Running Samba v$SAMBA_VERSION with build version: ${BUILD_TAG}"
 debug "USER: $(id)"
 debug "HOSTNAME: $(hostname)"
 

--- a/samba/rootfs/opt/samba/scripts/libutil.sh
+++ b/samba/rootfs/opt/samba/scripts/libutil.sh
@@ -11,8 +11,7 @@ if is_boolean_yes "${SAMBA_LOG_COLOR:-true}" ; then
   YELLOW='\033[38;5;3m'
 fi
 
-stderr_print() { printf "%b\\n" "${*}" >&2 ; }
-log() { stderr_print "${MAGENTA:-}$(date "+%T.%2N ")${RESET:-}${*}" ; }
+log() { printf "%b\\n" "${MAGENTA}$(date "+%T.%2N")${RESET} ${*}" >&2;}
 info() { log "${GREEN:-}INF0 ${RESET:-} ==> ${*}"; }
 warn() { log "${YELLOW:-}WARN ${RESET:-} ==> ${*}" ; }
 error() { log "${RED:-}ERROR${RESET:-} ==> ${*}" ; }


### PR DESCRIPTION
This pull request introduces changes to improve the handling of Samba versions, streamline the Docker build process, and enhance logging functionality. The most important changes include adding support for specifying Samba versions via build arguments, updating the Alpine base image, and refining logging utilities.

### Enhancements to Samba version handling:
* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L28-R29): Updated the `samba-repository-version` target to include a more robust command for extracting Samba version information and added a reference link to Alpine package details.
* [`samba/Dockerfile`](diffhunk://#diff-1a4c1bc6aa4889712a84992db95703320196a938ac8de939ba8085e730fb492aR23-R25): Introduced the `SAMBA_VERSION` build argument to allow specifying the Samba version during the build process and updated the package installation step to use this argument.
* [`samba/Dockerfile`](diffhunk://#diff-1a4c1bc6aa4889712a84992db95703320196a938ac8de939ba8085e730fb492aL87-R90): Added `SAMBA_VERSION` as an environment variable to make the version accessible within the container.

### Updates to Docker build process:
* [`samba/Dockerfile`](diffhunk://#diff-1a4c1bc6aa4889712a84992db95703320196a938ac8de939ba8085e730fb492aR1-R4): Changed the base image from `alpine` to `alpine:3` for improved compatibility and version control.

### Improvements to logging functionality:
* [`samba/rootfs/entrypoint.sh`](diffhunk://#diff-901a1777582dc2d1be54a2c331b20f51b0b36c1cf225512e95279857e53bc4bdL5-R5): Enhanced logging to include the Samba version in the startup message for better traceability.
* [`samba/rootfs/opt/samba/scripts/libutil.sh`](diffhunk://#diff-8e5bb17c5622c83b54a125d88053d40f6a748cab1a9ba4ce392006eaf00c85e5L14-R14): Simplified the `log` function by removing redundant code and ensuring consistent formatting of log messages.