### PR TITLE
Remove recycle:touch configuration from Dockerfile

### DIFF
--- a/samba/Dockerfile
+++ b/samba/Dockerfile
@@ -57,7 +57,6 @@ RUN apk --no-cache --no-progress upgrade && \
     echo '   recycle:keeptree = yes' >>$file && \
     echo '   recycle:maxsize = 0' >>$file && \
     echo '   recycle:repository = .recycle' >>$file && \
-    echo '   recycle:touch = yes' >>$file && \
     echo '   recycle:versions = yes' >>$file && \
     echo '' >>$file && \
     echo '   # Security' >>$file && \


### PR DESCRIPTION
This pull request makes a minor change to the Samba Dockerfile by removing the `recycle:touch = yes` configuration option. This option previously enabled updating the timestamp of recycled files, and its removal may affect how file timestamps are handled in the recycle bin.

- Removed the `recycle:touch = yes` setting from the Samba configuration in `samba/Dockerfile`, which disables automatic timestamp updates for recycled files.